### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ Protect your privacy. Send transactions on supported blockchain networks over cM
 ## How to Build
 
 Install the `astilectron-bundler`
+```sh
+go install github.com/asticode/go-astilectron-bundler/astilectron-bundler@latest
 ```
-go install github.com/asticode/go-astilectron-bundler/astilectron-bundler
+
+Clone this repository and navigate to its top level directory
+```sh
+git clone https://github.com/xx-labs/proxxy
+cd proxxy
 ```
 
 Run the build script `./build.sh`


### PR DESCRIPTION
README.md suggests to install a package without version info:

```sh
$ go install github.com/asticode/go-astilectron-bundler/astilectron-bundler
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/asticode/go-astilectron-bundler/astilectron-bundler@latest' to install the latest version
```

This update adds `@latest` as the message suggests.